### PR TITLE
Replaced unsupported RxTx library with jSerialComm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,11 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>org.rxtx</groupId>
-			<artifactId>rxtx</artifactId>
-			<version>2.1.7</version>
-		</dependency>
+		  <groupId>com.fazecast</groupId>
+		  <artifactId>jSerialComm</artifactId>
+		  <version>1.3.11</version>
+	  </dependency>
 	</dependencies>
-	<version>0.9.0</version>
+	<version>0.10.0</version>
 	<groupId>it.polito.elite</groupId>
 </project>

--- a/src/it/polito/elite/enocean/enj/link/PacketReceiver.java
+++ b/src/it/polito/elite/enocean/enj/link/PacketReceiver.java
@@ -17,9 +17,9 @@
  */
 package it.polito.elite.enocean.enj.link;
 
-import gnu.io.SerialPort;
-import gnu.io.SerialPortEvent;
-import gnu.io.SerialPortEventListener;
+import com.fazecast.jSerialComm.SerialPort;
+import com.fazecast.jSerialComm.SerialPortDataListener;
+import com.fazecast.jSerialComm.SerialPortEvent;
 import it.polito.elite.enocean.enj.util.ByteUtils;
 import it.polito.elite.enocean.protocol.serial.v3.network.packet.ESP3Packet;
 
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
  * @authr <a href="mailto:biasiandrea04@gmail.com">Andrea Biasi </a>
  * 
  */
-public class PacketReceiver implements SerialPortEventListener
+public class PacketReceiver implements SerialPortDataListener
 {
 	// the class logger
 	private Logger logger;
@@ -115,8 +115,13 @@ public class PacketReceiver implements SerialPortEventListener
 		this.packetLenght = -1;
 	}
 
+	@Override
+	public int getListeningEvents() {
+		return SerialPort.LISTENING_EVENT_DATA_AVAILABLE;
+	}
+
 	/**
-	 * @see {@link SerialPortEventListener}
+	 * @see {@link SerialPortDataListener}
 	 * 
 	 *      Listens for events on the attached serial port and handles incoming
 	 *      data, parsing ESP3 packets and putting them in the right message
@@ -131,7 +136,7 @@ public class PacketReceiver implements SerialPortEventListener
 			InputStream serialInputStream = this.serialPort.getInputStream();
 
 			// check if data is available
-			if (event.getEventType() == SerialPortEvent.DATA_AVAILABLE)
+			if (event.getEventType() == SerialPort.LISTENING_EVENT_DATA_AVAILABLE)
 			{
 				// read the incoming packet if data is available
 

--- a/src/it/polito/elite/enocean/enj/link/PacketTransmitter.java
+++ b/src/it/polito/elite/enocean/enj/link/PacketTransmitter.java
@@ -17,7 +17,7 @@
  */
 package it.polito.elite.enocean.enj.link;
 
-import gnu.io.SerialPort;
+import com.fazecast.jSerialComm.SerialPort;
 import it.polito.elite.enocean.enj.util.ByteUtils;
 
 import java.io.IOException;

--- a/src/it/polito/elite/enocean/enj/link/serial/SerialPortFactory.java
+++ b/src/it/polito/elite/enocean/enj/link/serial/SerialPortFactory.java
@@ -17,14 +17,7 @@
  */
 package it.polito.elite.enocean.enj.link.serial;
 
-import java.util.logging.Logger;
-
-import gnu.io.CommPort;
-import gnu.io.CommPortIdentifier;
-import gnu.io.NoSuchPortException;
-import gnu.io.PortInUseException;
-import gnu.io.SerialPort;
-import gnu.io.UnsupportedCommOperationException;
+import com.fazecast.jSerialComm.SerialPort;
 
 /**
  * A utility factory for getting a reference to the serial port used for
@@ -32,7 +25,7 @@ import gnu.io.UnsupportedCommOperationException;
  * correct parameters.
  * 
  * @author <a href="mailto:dario.bonino@gmail.com">Dario Bonino</a>
- * @authr <a href="mailto:biasiandrea04@gmail.com">Andrea Biasi </a>
+ * @author <a href="mailto:biasiandrea04@gmail.com">Andrea Biasi </a>
  * 
  */
 public class SerialPortFactory
@@ -54,62 +47,13 @@ public class SerialPortFactory
 	public static SerialPort getPort(String portName, int timeout) throws Exception
 	{
 		// the serial port reference, initially null
-		SerialPort serialPort = null;
-
-		Logger logger = Logger.getLogger(SerialPortFactory.class.getName());
-		
-		try
-		{
-
-			// sets the port name (TODO: check if needed)
-			System.setProperty("gnu.io.rxtx.SerialPorts", portName);
-
-			// build a port identifier given the port id as a string
-			CommPortIdentifier portIdentifier = CommPortIdentifier
-					.getPortIdentifier(portName);
-
-			// check that the port exists and is free
-			if (portIdentifier.isCurrentlyOwned())
-			{
-				logger.severe("Error: Port is currently in use");
-			}
-			else
-			{
-				// open the serial port
-				CommPort commPort = portIdentifier.open(
-						SerialPortFactory.class.getName(), timeout);
-
-				// check that the just opened communication port is actually a
-				// serial port.
-				if (commPort instanceof SerialPort)
-				{
-					// store the serial port reference
-					serialPort = (SerialPort) commPort;
-
-					// set the serial port parameters according to the ESP3
-					// specification:
-					// speed = 57600 bps
-					// data = 8 byte
-					// stop bit = 1
-					// parity = none
-					serialPort.setSerialPortParams(57600,
-							SerialPort.DATABITS_8, SerialPort.STOPBITS_1,
-							SerialPort.PARITY_NONE);
-				}
-				else
-				{
-					logger.severe("Error while opening and setting up the serial port.");
-				}
-			}
+		SerialPort serialPort = SerialPort.getCommPort(portName);
+		if (serialPort.getSystemPortName().equalsIgnoreCase("Bad Port")) {
+			throw new Exception("Error: Unrecognised port name " + portName);
 		}
-		catch (UnsupportedCommOperationException | NoSuchPortException
-				| PortInUseException e)
-		{
-			logger.severe("Exception while opening the serial port for communication:\n "+e);
-			//rethrow
-			throw e;
-		}
-
+		serialPort.setComPortParameters(57600, 8, SerialPort.ONE_STOP_BIT, SerialPort.NO_PARITY);
+		serialPort.setFlowControl(SerialPort.FLOW_CONTROL_DISABLED);
+		serialPort.setComPortTimeouts(SerialPort.TIMEOUT_NONBLOCKING, 0 ,0);
 		return serialPort;
 	}
 }


### PR DESCRIPTION
The RxTx serial library is long since out of support and requires some manual intervention on some platforms to function correctly.
So I have swapped it out for the JSerialComm library that is better supported, contains the native binaries for most platforms and doesn't require any manual manipulation of DLLs/shared libraries
I've tested this on Windows using the limited enOcean devices I have available here and it works fine for me.