### PR TITLE
Added intial version of support for A53808 EEP.

### DIFF
--- a/src/it/polito/elite/enocean/enj/eep/EEPRegistry.java
+++ b/src/it/polito/elite/enocean/enj/eep/EEPRegistry.java
@@ -101,6 +101,7 @@ public class EEPRegistry
 		eeps.add(it.polito.elite.enocean.enj.eep.eep26.A5.A502.A50230.class);
 		eeps.add(it.polito.elite.enocean.enj.eep.eep26.A5.A504.A50401.class);
 		eeps.add(it.polito.elite.enocean.enj.eep.eep26.A5.A507.A50701.class);
+		eeps.add(it.polito.elite.enocean.enj.eep.eep26.A5.A538.A53808.class);
 		eeps.add(it.polito.elite.enocean.enj.eep.eep26.D2.D201.D20106.class);
 		eeps.add(it.polito.elite.enocean.enj.eep.eep26.D2.D201.D20108.class);
 		eeps.add(it.polito.elite.enocean.enj.eep.eep26.D2.D201.D20109.class);

--- a/src/it/polito/elite/enocean/enj/eep/eep26/A5/A538/A538.java
+++ b/src/it/polito/elite/enocean/enj/eep/eep26/A5/A538/A538.java
@@ -1,0 +1,54 @@
+package it.polito.elite.enocean.enj.eep.eep26.A5.A538;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import it.polito.elite.enocean.enj.eep.EEP;
+import it.polito.elite.enocean.enj.eep.Rorg;
+import it.polito.elite.enocean.enj.eep.eep26.telegram.EEP26Telegram;
+import it.polito.elite.enocean.enj.eep.eep26.telegram.EEP26TelegramType;
+import it.polito.elite.enocean.enj.eep.eep26.telegram.FourBSTelegram;
+
+/**
+ * A class representing the A5-38 family of EnOcean Equipment Profiles
+ * (Central Command).
+ *
+ * @author <a href="mailto:kickass_kemmler@gmx.de">Jan Kemmler</a>
+ *
+ */
+public abstract class A538 extends EEP {
+    // the EEP26 definition, according to the EEP26 specification
+    public static final Rorg rorg = new Rorg((byte) 0xa5);
+    public static final byte func = (byte) 0x38;
+
+    // func must be defined by extending classes
+
+    // Executor Thread Pool for handling attribute updates
+    protected volatile ExecutorService attributeNotificationWorker;
+
+
+    /**
+     * The class constructor
+     */
+    public A538() {
+        // call the superclass constructor
+        super("2.6");
+
+        // build the attribute dispatching worker
+        this.attributeNotificationWorker = Executors.newFixedThreadPool(1);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * it.polito.elite.enocean.enj.eep.EEP#handleProfileUpdate(it.polito.elite
+     * .enocean.enj.eep.eep26.telegram.EEP26Telegram)
+     */
+    @Override
+    public boolean handleProfileUpdate(EEP26Telegram telegram) {
+        boolean success = true;
+        return success;
+    }
+
+}

--- a/src/it/polito/elite/enocean/enj/eep/eep26/A5/A538/A53808.java
+++ b/src/it/polito/elite/enocean/enj/eep/eep26/A5/A538/A53808.java
@@ -1,0 +1,116 @@
+package it.polito.elite.enocean.enj.eep.eep26.A5.A538;
+
+import it.polito.elite.enocean.enj.communication.EnJConnection;
+import it.polito.elite.enocean.enj.eep.EEPIdentifier;
+import it.polito.elite.enocean.enj.eep.eep26.attributes.EEP26DimLevel;
+
+
+/**
+ * A class representing the A5-38-08 EnOcean Equipment Profile.
+ * (Gateway control)
+ *
+ * @author <a href="mailto:kickass_kemmler@gmx.de">Jan Kemmler</a>
+ *
+ */
+public class A53808 extends A538 {
+
+    // the type definition
+    public static final byte type = (byte) 0x08;
+
+    // the used channel
+    public static int CHANNEL = 0;
+
+    // the byte identifier for all output channels
+    public static byte ALL_OUTPUT_CHANNEL = 0x1e;
+
+    /**
+     *
+     */
+    public A53808() {
+        super();
+
+        this.addChannelAttribute(A53808.CHANNEL, new EEP26DimLevel());
+    }
+
+    public void dimming(EnJConnection connection, byte[] deviceAddress, int dimValue, int dimTime, boolean isTeachIn,
+            boolean storeValue, boolean switchingCommand) {
+        // check limits
+        if (dimValue < 0) {
+            dimValue = 0;
+        } else if (dimValue > 100) {
+            dimValue = 100;
+        }
+
+        if (dimTime < 0) {
+            dimTime = 0;
+        } else if (dimTime > 255) {
+            dimTime = 255;
+        }
+
+        byte teachInByte = (byte) ((isTeachIn) ? 0 : 1);
+
+        byte storeValueByte = (byte) ((storeValue) ? 1 : 0);
+
+        byte switchingCommandByte = (byte) ((switchingCommand) ? 1 : 0);
+
+        // prepare the data payload to host "desired" values
+        byte dataByte[] = new byte[5];
+
+        // add the packet rorg
+        dataByte[0] = A538.rorg.getRorgValue();
+
+        // CMD code (0x01), the first 4 bits are not used
+        dataByte[1] = (byte) 0x02;
+
+        // Dim value
+        dataByte[2] = (byte) dimValue;
+
+        // Dim time
+        dataByte[3] = (byte) dimTime;
+
+        // teachin boolean: bit 3, dimming range: bit 2, store value boolean: bit 1, switching command boolean: bit 0
+        dataByte[4] = (byte) ((teachInByte << 3) + (0 << 2) + (storeValueByte << 1) + switchingCommandByte);
+
+        // send the payload for connection-layer encapsulation
+        connection.sendRadioCommand(deviceAddress, dataByte);
+
+    }
+
+    public void switching(EnJConnection connection, byte[] deviceAddress, boolean switchOn, boolean isTeachIn) {
+
+        byte teachInByte = (byte) ((isTeachIn) ? 0 : 1);
+
+        byte switchingCommandByte = (byte) ((switchOn) ? 1 : 0);
+
+        // prepare the data payload to host "desired" values
+        byte dataByte[] = new byte[4];
+
+        // add the packet rorg
+        dataByte[0] = A538.rorg.getRorgValue();
+
+        // CMD code (0x01), the first 4 bits are not used
+        dataByte[1] = (byte) 0x01;
+
+        // Time
+        dataByte[2] = (byte) 0x00;
+
+        // Dim value
+        dataByte[3] = (byte) ((teachInByte << 3) + switchingCommandByte);
+
+        // send the payload for connection-layer encapsulation
+        connection.sendRadioCommand(deviceAddress, dataByte);
+
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see it.polito.elite.enocean.enj.eep.EEP#getEEPIdentifier()
+     */
+    @Override
+    public EEPIdentifier getEEPIdentifier() {
+        // return the EEPIdentifier for this profile
+        return new EEPIdentifier(A538.rorg, A538.func, A53808.type);
+
+    }
+}


### PR DESCRIPTION
This PR introduces support for the A53808 EEP.

This is just an initial version that I present here to gather feedback and ask for help.

## HELP NEEDED:
I have had trouble testing this code as I am not sure how to teach in the gateway (pc) to the Eltako FUD61NPN that I own. I primarily wrote this code so that these actors would be supported.
However, I have not been able to teach-in my PC to the device and as such I have no idea if this even works.

The FUD61NPN I own has a sticker on it that says: 25/9
I am assuming that this means the unit was produced in the 25th week of 2009. I assume that this means it might not support certain profiles.
The printing on the device also has different indicators than the images I have found on the online documentation.

Do you have any idea how I should proceed? Do you perhaps have the ability to test if the profiles I have implemented here work?
What is the procedure to manually teach in the pc as a gateway into an actor? My procedure was to use a button in the software that I use to send a dimm telegram with the teach-in flag set. This however did not work.
Simply pressing an enocean rocker switch button did work for teach-in though, so the teach-in without a gateway does work.

Signed-off-by: Jan Kemmler <kickass_kemmler@gmx.de>